### PR TITLE
Add configs for making passportLike optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module.exports.kimyjwt = {
   secretField: "secret",
   // Optional
   idField: "id", // This is an attribute in the model
+  passportLike: false // defaults to true
 }
 ```
 
@@ -36,6 +37,22 @@ authentication and you're done:
     controller: 'UserController',
     action: 'mySecureRoute'
   }]
+```
+
+If you enable the Passport.js-like API then you can use the `req.user` object
+as you usually do in a Passport.js-based application:
+
+```javascript
+// UserController
+
+module.exports = {
+	secureRoute: function(req, res) {
+		res.json({
+			success: true,
+			message: "Welcome, " + req.user.name // Name is a property in the model
+		});
+	}
+};
 ```
 
 # Contribute

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ module.exports = function indexes(sails) {
     // Default config
     defaults: {
       kimyjwt: {
-        idField: "id"
+        idField: "id",
+        passportLike: true
       }
     },
 
@@ -20,18 +21,20 @@ module.exports = function indexes(sails) {
       var eventsToWaitFor = ["hook:orm:loaded", "hook:http:loaded", "hook:policies:loaded"];
 
       sails.after(eventsToWaitFor, function() {
-        // Required fields config
-        var UserModel = sails.models[sails.config.kimyjwt.model];
-        var secretField = sails.config.kimyjwt.secretField;
-        var idField = sails.config.kimyjwt.idField;
+        // Hook configs
+        var UserModel    = sails.models[sails.config.kimyjwt.model];
+        var secretField  = sails.config.kimyjwt.secretField;
+        var idField      = sails.config.kimyjwt.idField;
+        var passportLike = sails.config.kimyjwt.passportLike;
 
-        var fields = {
+        var options = {
           secretField: secretField,
-          idField: idField
+          idField: idField,
+          passportLike: passportLike
         }
 
         // Create the policy
-        sails.hooks.policies.middleware.kimyjwt = verify(UserModel, fields);
+        sails.hooks.policies.middleware.kimyjwt = verify(UserModel, options);
         sails.hooks.policies.middleware.kimyjwt.identity = "kimyjwt";
         sails.hooks.policies.middleware.kimyjwt.globalId = "kimyjwt";
         sails.hooks.policies.middleware.kimyjwt.sails = sails;
@@ -45,7 +48,7 @@ module.exports = function indexes(sails) {
   }
 };
 
-function verify(model, fields) {
+function verify(model, options) {
   return function(req, res, next) {
     var token = ext_token(req);
 
@@ -65,7 +68,7 @@ function verify(model, fields) {
     var payload = decoded.payload;
 
     var searchQuery = {};
-    searchQuery[fields.idField] = payload.sub;
+    searchQuery[options.idField] = payload.sub;
 
     model.findOne(searchQuery).exec(function(errFind, foundUser) {
       if (errFind) {
@@ -79,8 +82,10 @@ function verify(model, fields) {
             return res.status(401).send("Unauthorized");
           }
 
-          // When no error found the verification got success
-          req.user = foundUser.toJSON();
+          // When no error found the verification got success, so we can add
+          // the Passport-like behavior if needed and proceed with next()
+          if (options.passportLike) req.user = foundUser.toJSON();
+
           return next();
         });
       } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-kimyjwt",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JSON Web Tokens for Sails, made for humans.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-kimyjwt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "JSON Web Tokens for Sails, made for humans.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As said in #2 we're making the passport-like API optional in the application, so in the configuration file it is possible to disable it:

``` javascript
module.exports.kimyjwt = {
  // Required
  model: "user",
  secretField: "secret",
  // Optional
  idField: "id", // This is an attribute in the model
  passportLike: false // defaults to true
}
```

And then, in the controller, the `req.user` object will not be available.
