### PR TITLE
Magic object

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ authentication and you're done:
   }]
 ```
 
+## Options
+
+### Passport.js-like API
+
 If you enable the Passport.js-like API then you can use the `req.user` object
 as you usually do in a Passport.js-based application:
 
@@ -53,6 +57,42 @@ module.exports = {
 		});
 	}
 };
+```
+
+### Magic Object in `req.user`
+
+With the `passportLike` option enabled, the hook can attach the full model
+object to the `req.user` object. This adds the possibility to the following
+code to be used:
+
+```javascript
+// someController.js
+
+module.exports = {
+  myRoute: function(req, res) {
+    req.user.someMethodInTheModel();
+    // ...
+
+    res.json({
+      "success": true,
+      "message": "Well done, " + req.user.name + "!"
+    });
+  }
+};
+```
+
+For doing so just add the `magicObject` setting to true in the options
+
+```javascript
+module.exports.kimyjwt = {
+  // Required
+  model: "user",
+  secretField: "secret",
+  // Optional
+  idField: "id", // This is an attribute in the model
+  passportLike: true, // defaults to true
+  magicObject: true // defaults to false
+}
 ```
 
 # Contribute

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = function indexes(sails) {
     defaults: {
       kimyjwt: {
         idField: "id",
-        passportLike: true
+        passportLike: true,
+        magicObject: false
       }
     },
 
@@ -26,11 +27,19 @@ module.exports = function indexes(sails) {
         var secretField  = sails.config.kimyjwt.secretField;
         var idField      = sails.config.kimyjwt.idField;
         var passportLike = sails.config.kimyjwt.passportLike;
+        var magicObject  = sails.config.kimyjwt.magicObject;
 
         var options = {
           secretField: secretField,
           idField: idField,
-          passportLike: passportLike
+          passportLike: passportLike,
+          magicObject: magicObject
+        };
+
+        // Warning for Magic object enabled if the passportLike API is disabled
+        if (!passportLike && magicObject) {
+          sails.log.warn("Kimy JWT: Magic Object will not work. "
+            + "Enable the \"passportLike\" option in the settings");
         }
 
         // Create the policy
@@ -84,7 +93,13 @@ function verify(model, options) {
 
           // When no error found the verification got success, so we can add
           // the Passport-like behavior if needed and proceed with next()
-          if (options.passportLike) req.user = foundUser.toJSON();
+          if (options.passportLike) {
+            if (options.magicObject) {
+              req.user = foundUser;
+            } else {
+              req.user = foundUser.toJSON();
+            }
+          }
 
           return next();
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-kimyjwt",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "JSON Web Tokens for Sails, made for humans.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add the possibility to enable the use of the "magic" object in the `req.user` object passed in the Passsport.js-like API (This is mentioned in detail in #6 )
